### PR TITLE
Actually loop sources backwards and re-implement opaque check

### DIFF
--- a/image.go
+++ b/image.go
@@ -10,13 +10,17 @@ func analyzeAlpha(img image.Image) (bool, bool) {
 	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
 		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
 			_, _, _, a := img.At(x, y).RGBA()
-			// XXX this feels like a hack:
 			if a == 65535 || a == 0xff {
 				skip = false
+				if hasAlphaPixel {
+					return skip, hasAlphaPixel // return early
+				}
 			} else {
 				hasAlphaPixel = true
+				if !skip {
+					return skip, hasAlphaPixel // return early
+				}
 			}
-			// XXX could return early if one non-alpha pixel and one alpha pixel has been found.
 		}
 	}
 	return skip, hasAlphaPixel


### PR DESCRIPTION
Tested with various combinations of sources 