### PR TITLE
Allow nonexistent target

### DIFF
--- a/image.go
+++ b/image.go
@@ -21,6 +21,7 @@ func analyzeAlpha(img image.Image) (bool, bool) {
 					return skip, hasAlphaPixel // return early
 				}
 			}
+			// XXX could return early if one non-alpha pixel and one alpha pixel has been found.
 		}
 	}
 	return skip, hasAlphaPixel

--- a/image.go
+++ b/image.go
@@ -21,7 +21,6 @@ func analyzeAlpha(img image.Image) (bool, bool) {
 					return skip, hasAlphaPixel // return early
 				}
 			}
-			// XXX could return early if one non-alpha pixel and one alpha pixel has been found.
 		}
 	}
 	return skip, hasAlphaPixel

--- a/tileset.go
+++ b/tileset.go
@@ -22,7 +22,7 @@ func discoverTilesets(paths []string, target TilesetDescriptor, bestEffort bool)
 	var errors []error
 
 	for _, path := range paths {
-		backend, err := stringToBackend(path)
+		backend, err := stringToBackend(path, true)
 		if err != nil {
 			errors = append(errors, err)
 			continue


### PR DESCRIPTION
Doesn't fail if an empty (local filesystem) target directory is passed as the first argument. 

Try deleting `dataset/target` and test by running:
```./prioritile -zoom 1-8 dataset/target dataset/tiles_a dataset/tiles_b ```