### PR TITLE
Configure timeout for minio client explicitly

### DIFF
--- a/S3Backend/s3backend.go
+++ b/S3Backend/s3backend.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -40,9 +41,15 @@ func NewS3Backend(path string) (*S3Backend, error) {
 
 	accessKey := os.Getenv(host + "_" + bucket + "_ACCESS_KEY_ID")
 	secretKey := os.Getenv(host + "_" + bucket + "_SECRET_ACCESS_KEY")
+	transport, err := minio.DefaultTransport(secure)
+	if err != nil {
+		return nil, err
+	}
+	transport.ResponseHeaderTimeout = 60 * time.Second
 	minioClient, err := minio.New(host, &minio.Options{
-		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
-		Secure: secure,
+		Creds:     credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure:    secure,
+		Transport: transport,
 	})
 
 	if err != nil {

--- a/S3Backend/s3backend.go
+++ b/S3Backend/s3backend.go
@@ -19,7 +19,7 @@ type S3Backend struct {
 	BasePath string
 }
 
-func NewS3Backend(path string) (*S3Backend, error) {
+func NewS3Backend(path string, timeout int) (*S3Backend, error) {
 	url_parsed, err := url.Parse(path)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func NewS3Backend(path string) (*S3Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport.ResponseHeaderTimeout = 60 * time.Second
+	transport.ResponseHeaderTimeout = time.Duration(timeout) * time.Second
 	minioClient, err := minio.New(host, &minio.Options{
 		Creds:     credentials.NewStaticV4(accessKey, secretKey, ""),
 		Secure:    secure,

--- a/tileset.go
+++ b/tileset.go
@@ -17,12 +17,12 @@ func (t TilesetDescriptor) String() string {
 	return fmt.Sprintf("%d-%d", t.MaxZ, t.MinZ)
 }
 
-func discoverTilesets(paths []string, target TilesetDescriptor, bestEffort bool) ([]TilesetDescriptor, []error) {
+func discoverTilesets(paths []string, target TilesetDescriptor, bestEffort bool, timeout int) ([]TilesetDescriptor, []error) {
 	var tilesets []TilesetDescriptor
 	var errors []error
 
 	for _, path := range paths {
-		backend, err := stringToBackend(path, true)
+		backend, err := stringToBackend(path, true, timeout)
 		if err != nil {
 			errors = append(errors, err)
 			continue


### PR DESCRIPTION
Adds a program flag `timeout` that is used by the minio client. This allows to configure the response timeout to an S3 backend. The timeout is specified in seconds and has a default value of 60 (which is also the default used by minio).