### PR TITLE
List files recursively

### DIFF
--- a/FsBackend/fsbackend.go
+++ b/FsBackend/fsbackend.go
@@ -2,6 +2,7 @@ package FsBackend
 
 import (
 	"bytes"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -64,6 +65,25 @@ func (b *FsBackend) GetFiles(dirname string) ([]string, error) {
 		if !file.IsDir() {
 			results = append(results, files[idx].Name())
 		}
+	}
+	return results, nil
+}
+
+func (b *FsBackend) GetFilesRecursive(dirname string) ([]string, error) {
+	var results []string
+
+	err := filepath.Walk(filepath.Join(b.BasePath, dirname), func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			info.Name()
+			results = append(results, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return results, nil
 }

--- a/S3Backend/s3backend.go
+++ b/S3Backend/s3backend.go
@@ -127,6 +127,22 @@ func (s *S3Backend) GetFiles(dirname string) ([]string, error) {
 	return result, nil
 }
 
+func (s *S3Backend) GetFilesRecursive(dirname string) ([]string, error) {
+	prefix := s.BasePath + dirname
+	var result []string
+	for object := range s.Client.ListObjects(context.Background(),
+		s.Bucket,
+		minio.ListObjectsOptions{Prefix: prefix, Recursive: true},
+	) {
+		if object.Err != nil {
+			return nil, object.Err
+		}
+		// Process all files
+		result = append(result, object.Key[len(prefix):])
+	}
+	return result, nil
+}
+
 func (s *S3Backend) MkdirAll(dirname string) error {
 	// I think this is not necessary on S3
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/minio/minio-go/v7 v7.0.5
-	github.com/schollz/progressbar v1.0.0
 	github.com/schollz/progressbar/v3 v3.4.0
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/Qd
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/minio/md5-simd v1.1.0 h1:QPfiOqlZH+Cj9teu0t9b1nTBfPbyTl16Of5MeuShdK4=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
-github.com/minio/minio-go v1.0.0 h1:ooSujki+Z1PRGZsYffJw5jnF5eMBvzMVV86TLAlM0UM=
-github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
 github.com/minio/minio-go/v7 v7.0.5 h1:I2NIJ2ojwJqD/YByemC1M59e1b4FW9kS7NlOar7HPV4=
 github.com/minio/minio-go/v7 v7.0.5/go.mod h1:TA0CQCjJZHM5SJj9IjqR0NmpmQJ6bCbXifAJ3mUU6Hw=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
@@ -44,8 +42,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/schollz/progressbar v1.0.0 h1:gbyFReLHDkZo8mxy/dLWMr+Mpb1MokGJ1FqCiqacjZM=
-github.com/schollz/progressbar v1.0.0/go.mod h1:/l9I7PC3L3erOuz54ghIRKUEFcosiWfLvJv+Eq26UMs=
 github.com/schollz/progressbar/v3 v3.4.0 h1:jHd2FiF+zpPc7di1m9cHRgt8AaUvId3L5p4bF9Nux9g=
 github.com/schollz/progressbar/v3 v3.4.0/go.mod h1:Rp5lZwpgtYmlvmGo1FyDwXMqagyRBQYSDwzlP9QDu84=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -53,7 +49,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 type StorageBackend interface {
 	GetDirectories(dirname string) ([]string, error)
 	GetFiles(dirname string) ([]string, error)
+	GetFilesRecursive(dirname string) ([]string, error)
 	MkdirAll(dirname string) error
 	GetFile(filename string) ([]byte, error)
 	PutFile(filename string, content *bytes.Buffer) error

--- a/main.go
+++ b/main.go
@@ -128,16 +128,7 @@ func main() {
 		if !*quiet {
 			indexingBar.Add(1)
 		}
-		tiles, err := discoverTiles(tileset)
-		if err != nil {
-			if *bestEffort {
-				log.Println(err)
-				continue
-			} else {
-				log.Fatal(err)
-			}
-		}
-		for _, tile := range tiles {
+		for _, tile := range tileset.GetTiles() {
 			if have, ok := tilesDb[tile.String()]; ok {
 				tilesDb[tile.String()] = append(have, &sources[idx])
 			} else {

--- a/tile.go
+++ b/tile.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,45 +16,6 @@ type TileDescriptor struct {
 
 func (p TileDescriptor) String() string {
 	return fmt.Sprintf("%d/%d/%d.%s", p.Z, p.X, p.Y, p.Format)
-}
-
-func discoverTiles(tileset TilesetDescriptor) ([]TileDescriptor, error) {
-	var result []TileDescriptor
-	for z := tileset.MinZ; z <= tileset.MaxZ; z++ {
-		zPart := fmt.Sprintf("%d/", z)
-		xDirs, err := tileset.Backend.GetDirectories(zPart)
-		if err != nil {
-			return nil, err
-		}
-		for _, x := range xDirs {
-			xNum, err := strconv.Atoi(x)
-			if err != nil {
-				return nil, err
-			}
-			xPart := fmt.Sprintf("%s%d/", zPart, xNum)
-			yFiles, err := tileset.Backend.GetFiles(xPart)
-			if err != nil {
-				return nil, err
-			}
-			for _, y := range yFiles {
-				ySplit := strings.Split(y, ".")
-				if len(ySplit) != 2 {
-					return nil, errors.New("unknown file in tile dir")
-				}
-				yNum, err := strconv.Atoi(ySplit[0])
-				if err != nil {
-					return nil, err
-				}
-				result = append(result, TileDescriptor{
-					X:      xNum,
-					Y:      yNum,
-					Z:      z,
-					Format: ySplit[1],
-				})
-			}
-		}
-	}
-	return result, nil
 }
 
 func Str2Tile(tileSpec string) (*TileDescriptor, error) {

--- a/tileset.go
+++ b/tileset.go
@@ -2,15 +2,36 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 type TilesetDescriptor struct {
 	MaxZ    int
 	MinZ    int
 	Backend StorageBackend
+	Tiles   map[int][]TileDescriptor // <zoom, []tiles> mapping
+}
+
+func (t TilesetDescriptor) GetTiles() []TileDescriptor {
+	// Copy and sort keys of map
+	keys := make([]int, len(t.Tiles))
+	i := 0
+	for k := range t.Tiles {
+		keys[i] = k
+		i += 1
+	}
+	sort.Ints(keys)
+	// Extract all tiles to a sorted slice
+	var result []TileDescriptor
+	for k := range keys {
+		tileset := t.Tiles[k]
+		for _, s := range tileset {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 func (t TilesetDescriptor) String() string {
@@ -47,31 +68,74 @@ func discoverTilesets(paths []string, target TilesetDescriptor, bestEffort bool,
 }
 
 func discoverTileset(backend StorageBackend, minZ int, maxZ int) (TilesetDescriptor, error) {
-	files, err := backend.GetDirectories("")
+	files, err := backend.GetFilesRecursive("")
 	if err != nil {
 		return TilesetDescriptor{}, err
 	}
 
-	var z []int
-	for _, f := range files {
-		i, err := strconv.Atoi(f)
-		if i < minZ || (i > maxZ && maxZ != -1) {
-			continue
-		}
-		if err == nil {
-			z = append(z, i)
-		} else {
-			log.Printf("Invalid file '%s'", f)
-		}
-	}
-	if z == nil {
-		return TilesetDescriptor{}, fmt.Errorf("invalid or empty tileset")
-	}
-	sort.Ints(z)
-
-	return TilesetDescriptor{
-		MinZ:    z[0],
-		MaxZ:    z[len(z)-1],
+	result := TilesetDescriptor{
+		MinZ:    minZ,
+		MaxZ:    maxZ,
 		Backend: backend,
-	}, nil
+	}
+	err = buildTilesetStructure(files, &result)
+	if err != nil {
+		return TilesetDescriptor{}, fmt.Errorf("invalid or empty tileset: %w", err)
+	}
+	return result, nil
+}
+
+// Assumes the passed list of files is already sorted alphabetically.
+// Returns the respective Z/X/Y.png structure.
+func buildTilesetStructure(files []string, tileset *TilesetDescriptor) error {
+	var currentZoomLevel string
+	var tiles []TileDescriptor
+	tileset.Tiles = map[int][]TileDescriptor{}
+	for _, f := range files {
+		pathParts := strings.Split(f, "/")
+		if len(pathParts) != 3 {
+			return fmt.Errorf("invalid file path %s, expected format {z}/{x}/{y}.<ext>", f)
+		}
+		z := pathParts[0]
+		zNum, err := strconv.Atoi(z)
+		if err != nil {
+			return err
+		}
+		x := pathParts[1]
+		xNum, _ := strconv.Atoi(x)
+		if err != nil {
+			return err
+		}
+		y := pathParts[2]
+		// Get format
+		fileParts := strings.Split(y, ".")
+		if len(fileParts) != 2 {
+			return fmt.Errorf("invalid file path %s, expected format {z}/{x}/{y}.<ext>", f)
+		}
+		yNum, _ := strconv.Atoi(fileParts[0])
+		if err != nil {
+			return err
+		}
+		format := fileParts[1]
+		// Check zoom level
+		if z != currentZoomLevel {
+			// New zoom level
+			if zNum < tileset.MinZ || (tileset.MaxZ > 0 && zNum > tileset.MaxZ) {
+				// Filter out file based on specified zoom level boundaries
+				continue
+			}
+			currentZoomLevel = z
+			tiles = []TileDescriptor{}
+		}
+		// Add Z/X/Y (file)
+		tiles = append(tiles, TileDescriptor{
+			X:       xNum,
+			Y:       yNum,
+			Z:       zNum,
+			Format:  format,
+			TileSet: tileset,
+		})
+		tileset.Tiles[zNum] = tiles
+	}
+	return nil
 }

--- a/tileset_test.go
+++ b/tileset_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBuildTilesetStructure(t *testing.T) {
+	files := []string{
+		"5/15/19.png",
+		"5/16/19.png",
+		"6/31/38.png",
+		"6/32/38.png",
+		"7/63/77.png",
+		"7/64/77.png",
+		"8/127/154.png",
+		"8/127/155.png",
+		"8/128/154.png",
+		"8/128/155.png",
+		"9/254/309.png",
+		"9/254/310.png",
+		"9/255/309.png",
+		"9/255/310.png",
+		"9/255/311.png",
+		"9/256/309.png",
+		"9/256/310.png",
+		"9/256/311.png",
+	}
+	tileset := TilesetDescriptor{}
+	err := buildTilesetStructure(files, &tileset)
+	require.NoError(t, err)
+	require.Len(t, tileset.Tiles, 5)
+	// Zoom 5
+	tiles := tileset.Tiles[5]
+	assert.Len(t, tiles, 2)
+	// Zoom 6
+	tiles = tileset.Tiles[6]
+	assert.Len(t, tiles, 2)
+	// Zoom 7
+	tiles = tileset.Tiles[7]
+	assert.Len(t, tiles, 2)
+	// Zoom 8
+	tiles = tileset.Tiles[8]
+	assert.Len(t, tiles, 4)
+	// Zoom 9
+	tiles = tileset.Tiles[9]
+	assert.Len(t, tiles, 8)
+}
+
+func TestBuildTilesetStructureMinMax(t *testing.T) {
+	files := []string{
+		"5/15/19.png",
+		"5/16/19.png",
+		"6/31/38.png",
+		"6/32/38.png",
+		"7/63/77.png",
+		"7/64/77.png",
+		"8/127/154.png",
+		"8/127/155.png",
+		"8/128/154.png",
+		"8/128/155.png",
+		"9/254/309.png",
+		"9/254/310.png",
+		"9/255/309.png",
+		"9/255/310.png",
+		"9/255/311.png",
+		"9/256/309.png",
+		"9/256/310.png",
+		"9/256/311.png",
+	}
+	tileset := TilesetDescriptor{
+		MinZ: 7,
+		MaxZ: 8,
+	}
+	err := buildTilesetStructure(files, &tileset)
+	require.NoError(t, err)
+	require.Len(t, tileset.Tiles, 2)
+	// Zoom 7
+	tiles := tileset.Tiles[7]
+	assert.Len(t, tiles, 2)
+	// Zoom 8
+	tiles = tileset.Tiles[8]
+	assert.Len(t, tiles, 4)
+}
+
+func TestBuildTilesetStructureInvalid(t *testing.T) {
+	files := []string{
+		"6/",
+		"6/31/",
+		"6/31/38.png",
+		"6/32/",
+		"6/32/38.png",
+	}
+	tileset := TilesetDescriptor{}
+	err := buildTilesetStructure(files, &tileset)
+	require.Error(t, err)
+}


### PR DESCRIPTION
The PR is aimed mainly at improving performance. This is not a game-changer for FS backends. For S3 implementations, however, this can reduce the amount of LIST operations a lot, therefore reducing traffic/overhead and increasing performance.

The changes include a new `GetFilesRecursive` method to the backend interface. This lists only files, without considering directories.

The returned files are eventually "parsed" by the `buildTilesetStructure` function to create matching `TileDescriptor` structs. The added `tileset_test.go` file includes some tests for this function.