### PR TITLE
Fix GetTiles off-by-1 error

### DIFF
--- a/tileset.go
+++ b/tileset.go
@@ -25,7 +25,7 @@ func (t TilesetDescriptor) GetTiles() []TileDescriptor {
 	sort.Ints(keys)
 	// Extract all tiles to a sorted slice
 	var result []TileDescriptor
-	for k := range keys {
+	for _, k := range keys {
 		tileset := t.Tiles[k]
 		for _, s := range tileset {
 			result = append(result, s)


### PR DESCRIPTION
Fixed a bug in the recently introduced `GetTiles` function, which would use the indices instead of the zoom values for retrieving tile descriptors from within a Tileset.